### PR TITLE
Implement missing API in proto_definition

### DIFF
--- a/app/core/judger_server/model/contest.go
+++ b/app/core/judger_server/model/contest.go
@@ -4,7 +4,8 @@ import "gorm.io/gorm"
 
 type Contest struct {
 	gorm.Model
-	Title     string `json:"title" gorm:"type:varchar(255);not null"`
-	StartTime string `json:"start_time" gorm:"type:timestamp;not null"`
-	EndTime   string `json:"end_time" gorm:"type:timestamp;not null"`
+	Title       string `json:"title" gorm:"type:varchar(255);not null"`
+	Description string `json:"description" gorm:"type:text;not null"`
+	StartTime   string `json:"start_time" gorm:"type:timestamp;not null"`
+	EndTime     string `json:"end_time" gorm:"type:timestamp;not null"`
 }

--- a/app/core/judger_server/model/result.go
+++ b/app/core/judger_server/model/result.go
@@ -7,4 +7,7 @@ type Result struct {
 	SubmissionID uint   `json:"submission_id" gorm:"not null"`
 	Status       string `json:"status" gorm:"type:varchar(50);not null"`
 	TestCaseID   uint   `json:"test_case_id" gorm:"not null"`
+	Score        int    `json:"score" gorm:"not null"`
+	Time         int    `json:"time" gorm:"not null"`
+	Memory       int    `json:"memory" gorm:"not null"`
 }

--- a/app/core/judger_server/model/submission.go
+++ b/app/core/judger_server/model/submission.go
@@ -11,4 +11,8 @@ type Submission struct {
 	UserID    uint   `json:"user_id" gorm:"not null"`
 	Language  string `json:"language" gorm:"type:varchar(50);not null"`
 	Code      string `json:"code" gorm:"type:text;not null"`
+	Status    string `json:"status" gorm:"type:varchar(50);not null"`
+	Score     int    `json:"score" gorm:"not null"`
+	Time      int    `json:"time" gorm:"not null"`
+	Memory    int    `json:"memory" gorm:"not null"`
 }

--- a/app/core/judger_server/repo/contest_repo/repo.go
+++ b/app/core/judger_server/repo/contest_repo/repo.go
@@ -1,0 +1,92 @@
+package contest_repo
+
+import (
+	"context"
+
+	"github.com/Nanhtu187/Online-Judge/app/core/judger_server/model"
+	"gorm.io/gorm"
+)
+
+type IContestRepo interface {
+	UpsertContest(ctx context.Context, contestId int, title, description string, startTime, endTime string) (int, error)
+	GetContest(ctx context.Context, contestId int) (model.Contest, error)
+	GetListContestPreview(ctx context.Context, request GetListContestRequest) ([]ContestPreview, error)
+}
+
+type contestRepo struct {
+	db *gorm.DB
+}
+
+func (c *contestRepo) UpsertContest(ctx context.Context, contestId int, title, description string, startTime, endTime string) (int, error) {
+	var contest model.Contest
+	if contestId != 0 {
+		if err := c.db.First(&contest, contestId).Error; err != nil {
+			return 0, err
+		}
+		if title != "" {
+			contest.Title = title
+		}
+
+		if description != "" {
+			contest.Description = description
+		}
+
+		if startTime != "" {
+			contest.StartTime = startTime
+		}
+
+		if endTime != "" {
+			contest.EndTime = endTime
+		}
+
+		if err := c.db.Save(&contest).Error; err != nil {
+			return 0, err
+		}
+
+		return int(contest.ID), nil
+
+	} else {
+		contest.Title = title
+		contest.Description = description
+		contest.StartTime = startTime
+		contest.EndTime = endTime
+		if err := c.db.Create(&contest).Error; err != nil {
+			return 0, err
+		}
+		return int(contest.ID), nil
+	}
+}
+
+func (c *contestRepo) GetContest(ctx context.Context, contestId int) (model.Contest, error) {
+	var contest model.Contest
+	if err := c.db.First(&contest, contestId).Error; err != nil {
+		return model.Contest{}, err
+	}
+
+	return contest, nil
+}
+
+func (c *contestRepo) GetListContestPreview(ctx context.Context, request GetListContestRequest) ([]ContestPreview, error) {
+	var contests []ContestPreview
+	var query = c.db.Model(&model.Contest{})
+	if request.CreatedBy != 0 {
+		query = query.Where("created_by = ?", request.CreatedBy)
+	}
+
+	if request.Keywords != "" {
+		query = query.Where("title LIKE ?", "%"+request.Keywords+"%")
+	}
+
+	query = query.Offset(request.Offset).Limit(request.Limit).Take(&contests)
+	if err := query.Error; err != nil {
+		return nil, err
+	}
+
+	return contests, nil
+}
+
+func NewContestRepo(db *gorm.DB) IContestRepo {
+	return &contestRepo{
+		db: db,
+	}
+}

--- a/app/core/judger_server/repo/contest_repo/repo.go
+++ b/app/core/judger_server/repo/contest_repo/repo.go
@@ -77,7 +77,7 @@ func (c *contestRepo) GetListContestPreview(ctx context.Context, request GetList
 		query = query.Where("title LIKE ?", "%"+request.Keywords+"%")
 	}
 
-	query = query.Offset(request.Offset).Limit(request.Limit).Take(&contests)
+	query = query.Offset(request.Offset).Limit(request.Limit).Find(&contests)
 	if err := query.Error; err != nil {
 		return nil, err
 	}

--- a/app/core/judger_server/repo/result_repo/repo.go
+++ b/app/core/judger_server/repo/result_repo/repo.go
@@ -1,0 +1,101 @@
+package result_repo
+
+import (
+	"context"
+
+	"github.com/Nanhtu187/Online-Judge/app/core/judger_server/model"
+	"gorm.io/gorm"
+)
+
+type IResultRepo interface {
+	UpsertResult(ctx context.Context, resultId int, submissionId uint, status string, testCaseId uint, score, time, memory int) (int, error)
+	GetResult(ctx context.Context, resultId int) (model.Result, error)
+	GetListResults(ctx context.Context, request GetListResultsRequest) ([]ResultPreview, error)
+}
+
+type resultRepo struct {
+	db *gorm.DB
+}
+
+func (r *resultRepo) UpsertResult(ctx context.Context, resultId int, submissionId uint, status string, testCaseId uint, score, time, memory int) (int, error) {
+	var result model.Result
+	if resultId != 0 {
+		if err := r.db.First(&result, resultId).Error; err != nil {
+			return 0, err
+		}
+		if submissionId != 0 {
+			result.SubmissionID = submissionId
+		}
+		if status != "" {
+			result.Status = status
+		}
+		if testCaseId != 0 {
+			result.TestCaseID = testCaseId
+		}
+		if score != 0 {
+			result.Score = score
+		}
+		if time != 0 {
+			result.Time = time
+		}
+		if memory != 0 {
+			result.Memory = memory
+		}
+
+		if err := r.db.Save(&result).Error; err != nil {
+			return 0, err
+		}
+
+		return int(result.ID), nil
+
+	} else {
+		result.SubmissionID = submissionId
+		result.Status = status
+		result.TestCaseID = testCaseId
+		result.Score = score
+		result.Time = time
+		result.Memory = memory
+		if err := r.db.Create(&result).Error; err != nil {
+			return 0, err
+		}
+		return int(result.ID), nil
+	}
+}
+
+func (r *resultRepo) GetResult(ctx context.Context, resultId int) (model.Result, error) {
+	var result model.Result
+	if err := r.db.First(&result, resultId).Error; err != nil {
+		return model.Result{}, err
+	}
+
+	return result, nil
+}
+
+func (r *resultRepo) GetListResults(ctx context.Context, request GetListResultsRequest) ([]ResultPreview, error) {
+	var results []ResultPreview
+	var query = r.db.Model(&model.Result{})
+	if request.SubmissionId != 0 {
+		query = query.Where("submission_id = ?", request.SubmissionId)
+	}
+
+	if request.Status != "" {
+		query = query.Where("status = ?", request.Status)
+	}
+
+	if request.TestCaseId != 0 {
+		query = query.Where("test_case_id = ?", request.TestCaseId)
+	}
+
+	query = query.Offset(request.Offset).Limit(request.Limit).Take(&results)
+	if err := query.Error; err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}
+
+func NewResultRepo(db *gorm.DB) IResultRepo {
+	return &resultRepo{
+		db: db,
+	}
+}

--- a/app/core/judger_server/repo/submission_repo/repo.go
+++ b/app/core/judger_server/repo/submission_repo/repo.go
@@ -98,7 +98,7 @@ func (s *submissionRepo) GetListSubmissionPreview(ctx context.Context, request G
 		query = query.Where("code LIKE ?", "%"+request.Keywords+"%")
 	}
 
-	query = query.Offset(request.Offset).Limit(request.Limit).Take(&submissions)
+	query = query.Offset(request.Offset).Limit(request.Limit).Find(&submissions)
 	if err := query.Error; err != nil {
 		return nil, err
 	}

--- a/app/core/judger_server/repo/submission_repo/repo.go
+++ b/app/core/judger_server/repo/submission_repo/repo.go
@@ -1,0 +1,113 @@
+package submission_repo
+
+import (
+	"context"
+
+	"github.com/Nanhtu187/Online-Judge/app/core/judger_server/model"
+	"gorm.io/gorm"
+)
+
+type ISubmissionRepo interface {
+	UpsertSubmission(ctx context.Context, submissionId int, problemId, contestId, userId int, language, code, status string, score, time, memory int) (int, error)
+	GetSubmission(ctx context.Context, submissionId int) (model.Submission, error)
+	GetListSubmissionPreview(ctx context.Context, request GetListSubmissionRequest) ([]SubmissionPreview, error)
+}
+
+type submissionRepo struct {
+	db *gorm.DB
+}
+
+func (s *submissionRepo) UpsertSubmission(ctx context.Context, submissionId int, problemId, contestId, userId int, language, code, status string, score, time, memory int) (int, error) {
+	var submission model.Submission
+	if submissionId != 0 {
+		if err := s.db.First(&submission, submissionId).Error; err != nil {
+			return 0, err
+		}
+		if problemId != 0 {
+			submission.ProblemID = uint(problemId)
+		}
+		if contestId != 0 {
+			submission.ContestID = uint(contestId)
+		}
+		if userId != 0 {
+			submission.UserID = uint(userId)
+		}
+		if language != "" {
+			submission.Language = language
+		}
+		if code != "" {
+			submission.Code = code
+		}
+		if status != "" {
+			submission.Status = status
+		}
+		if score != 0 {
+			submission.Score = score
+		}
+		if time != 0 {
+			submission.Time = time
+		}
+		if memory != 0 {
+			submission.Memory = memory
+		}
+
+		if err := s.db.Save(&submission).Error; err != nil {
+			return 0, err
+		}
+
+		return int(submission.ID), nil
+
+	} else {
+		submission.ProblemID = uint(problemId)
+		submission.ContestID = uint(contestId)
+		submission.UserID = uint(userId)
+		submission.Language = language
+		submission.Code = code
+		submission.Status = status
+		submission.Score = score
+		submission.Time = time
+		submission.Memory = memory
+		if err := s.db.Create(&submission).Error; err != nil {
+			return 0, err
+		}
+		return int(submission.ID), nil
+	}
+}
+
+func (s *submissionRepo) GetSubmission(ctx context.Context, submissionId int) (model.Submission, error) {
+	var submission model.Submission
+	if err := s.db.First(&submission, submissionId).Error; err != nil {
+		return model.Submission{}, err
+	}
+
+	return submission, nil
+}
+
+func (s *submissionRepo) GetListSubmissionPreview(ctx context.Context, request GetListSubmissionRequest) ([]SubmissionPreview, error) {
+	var submissions []SubmissionPreview
+	var query = s.db.Model(&model.Submission{})
+	if request.ContestId != 0 {
+		query = query.Where("contest_id = ?", request.ContestId)
+	}
+
+	if request.UserId != 0 {
+		query = query.Where("user_id = ?", request.UserId)
+	}
+
+	if request.Keywords != "" {
+		query = query.Where("code LIKE ?", "%"+request.Keywords+"%")
+	}
+
+	query = query.Offset(request.Offset).Limit(request.Limit).Take(&submissions)
+	if err := query.Error; err != nil {
+		return nil, err
+	}
+
+	return submissions, nil
+}
+
+func NewSubmissionRepo(db *gorm.DB) ISubmissionRepo {
+	return &submissionRepo{
+		db: db,
+	}
+}

--- a/app/core/judger_server/service/server/server.go
+++ b/app/core/judger_server/service/server/server.go
@@ -83,6 +83,126 @@ func (s *Server) UpsertSubmissions(ctx context.Context, request *judger_server.U
 	}, nil
 }
 
+func (s *Server) UpsertContest(ctx context.Context, request *judger_server.UpsertContestRequest) (*judger_server.UpsertContestResponse, error) {
+	req, err := validateUpsertContestRequest(request)
+	if err != nil {
+		return nil, err
+	}
+	id, err := s.service.UpsertContest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return &judger_server.UpsertContestResponse{
+		Code:    200,
+		Message: "success",
+		Data: &judger_server.ContestResponseData{
+			ContestId: int32(id),
+		},
+	}, nil
+}
+
+func (s *Server) GetContest(ctx context.Context, request *judger_server.GetContestRequest) (*judger_server.GetContestResponse, error) {
+	req, err := validateGetContestRequest(request)
+	if err != nil {
+		return nil, err
+	}
+	contest, err := s.service.GetContest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return &judger_server.GetContestResponse{
+		Code:    200,
+		Message: "success",
+		Data:    contest,
+	}, nil
+}
+
+func (s *Server) GetListContests(ctx context.Context, request *judger_server.GetListContestsRequest) (*judger_server.GetListContestsResponse, error) {
+	req, err := validateGetListContestsRequest(request)
+	if err != nil {
+		return nil, err
+	}
+	contests, err := s.service.GetListContests(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return &judger_server.GetListContestsResponse{
+		Code:    200,
+		Message: "success",
+		Data: &judger_server.GetListContestsResponseData{
+			Contests: contests,
+		},
+	}, nil
+}
+
+func (s *Server) GetSubmission(ctx context.Context, request *judger_server.GetSubmissionRequest) (*judger_server.GetSubmissionResponse, error) {
+	req, err := validateGetSubmissionRequest(request)
+	if err != nil {
+		return nil, err
+	}
+	submission, err := s.service.GetSubmission(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return &judger_server.GetSubmissionResponse{
+		Code:    200,
+		Message: "success",
+		Data:    submission,
+	}, nil
+}
+
+func (s *Server) GetListSubmissions(ctx context.Context, request *judger_server.GetListSubmissionsRequest) (*judger_server.GetListSubmissionsResponse, error) {
+	req, err := validateGetListSubmissionsRequest(request)
+	if err != nil {
+		return nil, err
+	}
+	submissions, err := s.service.GetListSubmissions(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return &judger_server.GetListSubmissionsResponse{
+		Code:    200,
+		Message: "success",
+		Data: &judger_server.GetListSubmissionsResponseData{
+			Submissions: submissions,
+		},
+	}, nil
+}
+
+func (s *Server) GetListResults(ctx context.Context, request *judger_server.GetListResultsRequest) (*judger_server.GetListResultsResponse, error) {
+	req, err := validateGetListResultsRequest(request)
+	if err != nil {
+		return nil, err
+	}
+	results, err := s.service.GetListResults(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return &judger_server.GetListResultsResponse{
+		Code:    200,
+		Message: "success",
+		Data: &judger_server.GetListResultsResponseData{
+			Results: results,
+		},
+	}, nil
+}
+
+func (s *Server) GetResult(ctx context.Context, request *judger_server.GetResultRequest) (*judger_server.GetResultResponse, error) {
+	req, err := validateGetResultRequest(request)
+	if err != nil {
+		return nil, err
+	}
+	result, err := s.service.GetResult(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return &judger_server.GetResultResponse{
+		Code:    200,
+		Message: "success",
+		Data:    result,
+	}, nil
+}
+
 func NewServer(db *gorm.DB, rdb *redis.Client) *Server {
 	return &Server{
 		service: NewService(db, rdb),


### PR DESCRIPTION
Implement missing API methods in `proto_definition/proto/core/judger_server/v1/server.proto` and corresponding server methods in `app/core/judger_server/service/server/server.go`.

* **Server Methods:**
  - Add `UpsertContest`, `GetContest`, `GetListContests`, `GetSubmission`, `GetListSubmissions`, `GetListResults`, and `GetResult` methods in `server.go`.
  - Implement validation and service calls for each method.

* **Models:**
  - Update `Contest` model in `contest.go` to include `Description`.
  - Update `Result` model in `result.go` to include `Score`, `Time`, and `Memory`.
  - Update `Submission` model in `submission.go` to include `Status`, `Score`, `Time`, and `Memory`.

* **Repositories:**
  - Add `contest_repo/repo.go` with `IContestRepo` interface and its implementation.
  - Add `submission_repo/repo.go` with `ISubmissionRepo` interface and its implementation.
  - Add `result_repo/repo.go` with `IResultRepo` interface and its implementation.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Nanhtu187/Online-Judge/pull/10?shareId=81cf0b2a-2897-4457-9fff-a5a8c203728b).